### PR TITLE
Update clearingway and moddingway

### DIFF
--- a/k8s/bases/clearingway/deployment.yaml
+++ b/k8s/bases/clearingway/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         runAsUser: 1000
       containers:
       - name: clearingway
-        image: ghcr.io/veraticus/clearingway:sha-93ce123
+        image: ghcr.io/veraticus/clearingway:sha-abc5470
         envFrom:
         - secretRef:
             name: env

--- a/k8s/bases/moddingway/deployment.yaml
+++ b/k8s/bases/moddingway/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       - name: github
       containers:
       - name: moddingway
-        image: ghcr.io/naurffxiv/moddingway:sha-6d6eeff
+        image: ghcr.io/naurffxiv/moddingway:sha-1dc53f4
         envFrom:
         - secretRef:
             name: env


### PR DESCRIPTION
This commit updates clearingway and moddingway with the following changes.

Clearingway: Fixes a bug where kill count isn't calculated correctly if the user has nonstandard composition kills.
Moddingway: Implements the /ban command.