### PR TITLE
moddingway - ban users not in server, clean up automod

### DIFF
--- a/k8s/bases/moddingway/app.yaml
+++ b/k8s/bases/moddingway/app.yaml
@@ -22,7 +22,7 @@ spec:
       - name: github
       containers:
       - name: app
-        image: ghcr.io/naurffxiv/moddingway:app-766174e
+        image: ghcr.io/naurffxiv/moddingway:app-73e8220
         envFrom:
         - secretRef:
             name: env


### PR DESCRIPTION
Allow ban command to work on users not in the server
remove one old thread from automod